### PR TITLE
Release 5.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 5.1.1 (2021-11-10)
+
+- Fixed an issue with `skyAgGridRowDelete` when using an infinite row model type. [#164](https://github.com/blackbaud/skyux-ag-grid/pull/164)
+
 # 5.1.0 (2021-10-29)
 
 - Added the lookup cell type. [#157](https://github.com/blackbaud/skyux-ag-grid/pull/157)

--- a/projects/ag-grid/package.json
+++ b/projects/ag-grid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skyux/ag-grid",
-  "version": "5.1.0",
+  "version": "5.1.1",
   "peerDependencies": {
     "@angular/common": "^12.2.13",
     "@angular/core": "^12.2.13",


### PR DESCRIPTION
- Fixed an issue with `skyAgGridRowDelete` when using an infinite row model type. [#164](https://github.com/blackbaud/skyux-ag-grid/pull/164)
